### PR TITLE
Fix for issue requiring implicit null casting as of PHP 8.4

### DIFF
--- a/src/debug/database/PdoQueryCapture.php
+++ b/src/debug/database/PdoQueryCapture.php
@@ -22,7 +22,7 @@ class PdoQueryCapture extends \flight\database\PdoWrapper {
 	 * @param string|null $password password
 	 * @param array       $options  options
 	 */
-	public function __construct(string $dsn, string $username = null, string $password = null, array $options = []) {
+	public function __construct(string $dsn, ?string $username = null, ?string $password = null, array $options = []) {
 		parent::__construct($dsn, $username, $password, $options);
 		$this->setAttribute(PDO::ATTR_STATEMENT_CLASS, [PdoQueryCaptureStatement::class, [$this]]);
 	}

--- a/src/debug/tracy/TracyExtensionLoader.php
+++ b/src/debug/tracy/TracyExtensionLoader.php
@@ -20,7 +20,7 @@ class TracyExtensionLoader {
 	 * @param Engine|null $app    Flight engine instance
 	 * @param array       $config Additional configuration options
 	 */
-	public function __construct(Engine $app = null, array $config = []) {
+	public function __construct(?Engine $app = null, array $config = []) {
 		if(Debugger::isEnabled() === false) {
 			throw new Exception('You need to enable Tracy\Debugger before using this extension!');
 		}


### PR DESCRIPTION
`flight\debug\tracy\TracyExtensionLoader::__construct(): Implicitly marking parameter $app as nullable is deprecated, the explicit nullable type must be used instead`

The error is from PHP 8.4 changes.

https://dev.to/gromnan/fix-php-84-deprecation-implicitly-marking-parameter-as-nullable-is-deprecated-the-explicit-nullable-type-must-be-used-instead-5gp3